### PR TITLE
[.NET 5] Added jenkinsfile to push nuget package

### DIFF
--- a/Jenkinsfile_BuildPipeMethodCallsNuget.groovy
+++ b/Jenkinsfile_BuildPipeMethodCallsNuget.groovy
@@ -24,7 +24,7 @@ pipeline {
     }
     parameters {
         string(name: "latestVersion", description: "The value of the version to deploy.")
-        booleanParam(name: 'publishPrivatePackages', description: 'Whether to publish private packages.', defaultValue: true)
+        booleanParam(name: 'publishNuGetPackage', description: 'Whether to publish NuGet package.', defaultValue: true)
     }
     
     stages {
@@ -62,9 +62,9 @@ pipeline {
             }
         }
         
-        stage('Publish Private NuGet Packages') {
+        stage('Publish NuGet Package') {
             when {
-                expression { return currentBuild.currentResult == 'SUCCESS' && params.publishPrivatePackages }
+                expression { return currentBuild.currentResult == 'SUCCESS' && params.publishNuGetPackage }
             }
 
             steps {

--- a/Jenkinsfile_BuildPipeMethodCallsNuget.groovy
+++ b/Jenkinsfile_BuildPipeMethodCallsNuget.groovy
@@ -70,6 +70,7 @@ pipeline {
             steps {
                 script {
                     bat "nuget pack PipeMethodCalls.nuspec -properties version=${completeVersion}"
+                    bat "nuget push *.nupkg"
                 }
                 echo "The nuget package for PipeMethodCalls has been published."
             }

--- a/Jenkinsfile_BuildPipeMethodCallsNuget.groovy
+++ b/Jenkinsfile_BuildPipeMethodCallsNuget.groovy
@@ -1,0 +1,85 @@
+library(
+    identifier: "jenkins-common-lib@v1.5",
+    retriever: modernSCM(github(credentialsId: "github-app-dev", repository: "jenkins-common-lib", repoOwner: "coveo")),
+    changelog: false
+)
+
+import java.text.SimpleDateFormat
+
+def latestVersionStr = ""
+
+pipeline {
+    agent {
+        node {
+            label 'windows'
+            customWorkspace "wks\\PipeMethodCallsNugetCreate"
+        }
+    }
+    options {
+        ansiColor('xterm')
+        buildDiscarder(logRotator(numToKeepStr: "30"))
+        disableConcurrentBuilds()
+        timeout(time: 2, unit: 'HOURS')
+        timestamps()
+    }
+    parameters {
+        string(name: "latestVersion", description: "The value of the version to deploy.")
+        booleanParam(name: 'publishPrivatePackages', description: 'Whether to publish private packages.', defaultValue: true)
+    }
+    
+    stages {
+        stage('Checkout') {
+            steps {
+                checkout([
+                    $class: 'GitSCM',
+                    branches: [[name: '*/master']],
+                    userRemoteConfigs: [[url: 'https://github.com/coveord/PipeMethodCalls',credentialsId:'github-app-dev']],
+                    clean: true
+                ])
+            }
+        }
+
+        stage('Init') {
+            steps {
+                script {
+                    latestVersionStr = params.latestVersion
+                    if(latestVersionStr != ""){
+                        completeVersion = "${latestVersionStr}"
+                    } 
+                    
+                    currentBuild.displayName = "#${env.BUILD_NUMBER} - v${completeVersion}"
+                }
+                echo "The version for this build will be: ${completeVersion}"
+            }
+        }
+
+        stage('Build') {
+            steps {
+                echo "Building the PipeMethodCalls library."
+                script { 
+                   bat "dotnet build -c Release"
+                }
+            }
+        }
+        
+        stage('Publish Private NuGet Packages') {
+            when {
+                expression { return currentBuild.currentResult == 'SUCCESS' && params.publishPrivatePackages }
+            }
+
+            steps {
+                script {
+                    bat "nuget pack PipeMethodCalls.nuspec -properties version=${completeVersion}"
+                }
+                echo "The nuget package for PipeMethodCalls has been published."
+            }
+        }
+    }
+
+    post {
+        cleanup {
+            dir ("bin") { deleteDir() }
+            dir ("obj") { deleteDir() }
+        }
+    }
+}


### PR DESCRIPTION
**Overview**: The purpose of this PR is to create a Jenkins file to create and push the NuGet package for the PipeMethodCalls library. I've added the Jenkins file to this repository instead of the connectors, because it made it a little complicated to have the Jenkins job deal with two different repositories. To keep it simple, I've added it to this repository, especially since it has nothing to do with the connectors code.  

**Note**: After speaking with Gaetan, we've decided to manually trigger this job when needed. In our next JIRA, we will do the necessary changes to this library, and create its corresponding NuGet package. After that, we shouldn't need to update this library anymore, unless any bugs are introduced. This is why I've added the parameter to explicitly specify the version of the package, so that we can control it. 

**Successful Jenkins build**: https://ctbuilds.dev.cloud.coveo.com/view/Connectors/job/Connectors_Publish_PipeMethodCalls_Nuget/24/

**JIRA**: https://coveord.atlassian.net/browse/CT-7598

**Private NuGet server with our package**: https://nuget.dev.cloud.coveo.com/packages/PipeMethodCalls 