### PR TITLE
[.NET 5] Added cleanup step in jenkins job + ask for dll in nuspec

### DIFF
--- a/Jenkinsfile_BuildPipeMethodCallsNuget.groovy
+++ b/Jenkinsfile_BuildPipeMethodCallsNuget.groovy
@@ -21,6 +21,7 @@ pipeline {
         disableConcurrentBuilds()
         timeout(time: 2, unit: 'HOURS')
         timestamps()
+        skipDefaultCheckout(true)
     }
     parameters {
         string(name: "latestVersion", description: "The value of the version to deploy.")
@@ -30,6 +31,7 @@ pipeline {
     stages {
         stage('Checkout') {
             steps {
+                cleanWs()
                 checkout([
                     $class: 'GitSCM',
                     branches: [[name: '*/master']],

--- a/PipeMethodCalls.nuspec
+++ b/PipeMethodCalls.nuspec
@@ -12,4 +12,9 @@
       <group targetFramework="netstandard2.0" />
     </dependencies>
   </metadata>
+  <files>
+    <file src="PipeMethodCalls\bin\Debug\netstandard2.0\*.dll" target="lib" />
+    <file src="PipeMethodCalls\bin\Debug\netstandard2.0\*.pdb" target="lib" />
+    <file src="PipeMethodCalls\bin\Debug\netstandard2.0\*.json" target="lib" />
+</files>
 </package>


### PR DESCRIPTION
**Overview**: The purpose of this PR is to add a step in the jenkins pipeline, to cleanup the workspace before we checkout and build. Without it, the job seems to use old build packages to publish to NuGet. With this fix, it should start with a clean workspace, and build the latest commit on master, and use that to publish to NuGet. 

**Build with clean workspace**: https://ctbuilds.dev.cloud.coveo.com/view/Connectors/job/Connectors_Publish_PipeMethodCalls_Nuget/29/console

**Build without clean workspace**: 
https://ctbuilds.dev.cloud.coveo.com/view/Connectors/job/Connectors_Publish_PipeMethodCalls_Nuget/25/console

**JIRA**: https://coveord.atlassian.net/browse/CTCORE-7669