### PR TITLE
[.NET 5] Switched files in nuspec from debug to release

### DIFF
--- a/PipeMethodCalls.nuspec
+++ b/PipeMethodCalls.nuspec
@@ -13,8 +13,8 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="PipeMethodCalls\bin\Debug\netstandard2.0\*.dll" target="lib" />
-    <file src="PipeMethodCalls\bin\Debug\netstandard2.0\*.pdb" target="lib" />
-    <file src="PipeMethodCalls\bin\Debug\netstandard2.0\*.json" target="lib" />
+    <file src="PipeMethodCalls\bin\Release\netstandard2.0\*.dll" target="lib" />
+    <file src="PipeMethodCalls\bin\Release\netstandard2.0\*.pdb" target="lib" />
+    <file src="PipeMethodCalls\bin\Release\netstandard2.0\*.json" target="lib" />
 </files>
 </package>


### PR DESCRIPTION
**Overview**: Sorry, I made a mistake in the previous changeset, where I had placed "Debug" folder instead of "Release". It couldn't recognize the Debug path on jenkins, which caused the job to fail. 

**Test**: In this jenkins run https://ctbuilds.dev.cloud.coveo.com/view/Connectors/job/Connectors_Publish_PipeMethodCalls_Nuget/42/console you will see the output of files included in the path I added. So this should work. 

**JIRA**: https://coveord.atlassian.net/browse/CTCORE-7669