### PR TITLE
[.NET 5] Updated PipeMethodCalls jenkins job and nuspec files

### DIFF
--- a/Jenkinsfile_BuildPipeMethodCallsNuget.groovy
+++ b/Jenkinsfile_BuildPipeMethodCallsNuget.groovy
@@ -71,8 +71,13 @@ pipeline {
 
             steps {
                 script {
-                    bat "nuget pack PipeMethodCalls.nuspec -properties version=${completeVersion}"
-                    bat "nuget push *.nupkg"
+                    bat "dotnet pack ./PipeMethodCalls/PipeMethodCalls.csproj -c Release --include-symbols --no-dependencies -p:PackageVersion=${completeVersion};TargetFrameworks=netstandard2.0"
+                    
+                    dir("${env.WORKSPACE}/PipeMethodCalls/bin/Release"){
+                        script {
+                            bat "dotnet nuget push *.nupkg --skip-duplicate"
+                        }
+                    }
                 }
                 echo "The nuget package for PipeMethodCalls has been published."
             }

--- a/PipeMethodCalls.nuspec
+++ b/PipeMethodCalls.nuspec
@@ -13,8 +13,8 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="PipeMethodCalls\bin\Release\netstandard2.0\*.dll" target="lib" />
-    <file src="PipeMethodCalls\bin\Release\netstandard2.0\*.pdb" target="lib" />
-    <file src="PipeMethodCalls\bin\Release\netstandard2.0\*.json" target="lib" />
+    <file src="PipeMethodCalls\bin\Release\netstandard2.0\*.dll" target="lib\netstandard2.0" />
+    <file src="PipeMethodCalls\bin\Release\netstandard2.0\*.pdb" target="lib\netstandard2.0" />
+    <file src="PipeMethodCalls\bin\Release\netstandard2.0\*.json" target="lib\netstandard2.0" />
 </files>
 </package>


### PR DESCRIPTION
**Overview**: I apologize for the trial and errors, but this should (hopefully) be the last change. I've updated the jenkins file to use dotnet pack instead of the nuspec file, as it does the packing for you. I've also updated the nuspec file to update the folder of the dll files to `lib\netstandard2.0`. It seems that Visual Studio will only recognize this particular folder path. Otherwise, it can't find the dll properly. Once this is merged, I will be able to test if the nuspec file will work (I've tested it locally, but not on Jenkins yet). If for whatever reason, it causes other issues, then we can just keep dotnet pack and remove the nuspec file. 

**JIRA**: https://coveord.atlassian.net/browse/CTCORE-7672

**Test**: https://ctbuilds.dev.cloud.coveo.com/view/Connectors/job/Connectors_Publish_PipeMethodCalls_Nuget/52/console this is the successful build with the change that I did in the Jenkinsfile. You can see the reply with my changes. 