### PR TITLE
[PipeMethodCalls] Update package name

### DIFF
--- a/PipeMethodCalls.nuspec
+++ b/PipeMethodCalls.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>PipeMethodCalls</id>
+    <id>Coveo.PipeMethodCalls</id>
     <version>$version$</version>
     <authors>Coveo Connectors Team</authors>
     <owners>RandomEngy</owners>


### PR DESCRIPTION
**Overview**: Due to security reasons with Coveo, I updated the package name to `Coveo.PipeMethodCalls`. 

**Next steps**:
- Once this PR is merged, we'll need to trigger a build in https://ctbuilds.dev.cloud.coveo.com/view/Connectors/job/Connectors_Publish_PipeMethodCalls_Nuget/ to create the Nuget package with the new name. 
- Then, we'll need to update the new package name in our connectors projects that use this library. 

**JIRA**: https://coveord.atlassian.net/browse/CTCORE-7734